### PR TITLE
Feat/대회 신청 및 시작/종료

### DIFF
--- a/apps/competition-service/build.gradle
+++ b/apps/competition-service/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'org.postgresql:postgresql'
-
+    implementation 'org.springframework.kafka:spring-kafka'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/CompetitionService.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/CompetitionService.java
@@ -33,4 +33,8 @@ public interface CompetitionService {
     void delete(UUID competitionId, String deletedBy);
 
     List<CompetitionChangeNotice> findChangeNotices(UUID competitionId);
+
+    Competition start(UUID competitionId);
+
+    Competition finish(UUID competitionId);
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/CompetitionServiceImpl.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/CompetitionServiceImpl.java
@@ -4,14 +4,19 @@ import common.exception.BusinessException;
 import common.exception.ErrorCode;
 import io.antcamp.competitionservice.application.dto.CreateCompetitionCommand;
 import io.antcamp.competitionservice.application.dto.UpdateCompetitionCommand;
+import io.antcamp.competitionservice.application.event.CompetitionEventProducer;
+import io.antcamp.competitionservice.domain.event.payload.CompetitionStartedPayload;
 import io.antcamp.competitionservice.domain.model.Competition;
 import io.antcamp.competitionservice.domain.model.CompetitionChangeNotice;
 import io.antcamp.competitionservice.domain.model.CompetitionPeriod;
 import io.antcamp.competitionservice.domain.model.CompetitionStatus;
+import io.antcamp.competitionservice.domain.model.JoinHistory;
 import io.antcamp.competitionservice.domain.model.ParticipantCount;
 import io.antcamp.competitionservice.domain.model.RegisterPeriod;
 import io.antcamp.competitionservice.domain.repository.CompetitionChangeNoticeRepository;
 import io.antcamp.competitionservice.domain.repository.CompetitionRepository;
+import io.antcamp.competitionservice.domain.repository.JoinHistoryRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +31,9 @@ public class CompetitionServiceImpl implements CompetitionService {
 
     private final CompetitionRepository competitionRepository;
     private final CompetitionChangeNoticeRepository competitionChangeNoticeRepository;
+    private final JoinHistoryRepository joinHistoryRepository;
+    private final CompetitionEventProducer competitionEventProducer;
+
 
     @Override
     @Transactional
@@ -124,12 +132,33 @@ public class CompetitionServiceImpl implements CompetitionService {
         return competitionChangeNoticeRepository.findAllByCompetitionId(competitionId);
     }
 
+    @Override
     @Transactional
     public Competition start(UUID competitionId) {
         Competition competition = competitionRepository.findById(competitionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
+
+        // 1. 도메인 상태 변경 (PREPARING -> ONGOING)
         competition.startCompetition();
-        return competitionRepository.save(competition);
+        Competition saved = competitionRepository.save(competition);
+
+        // 2. 참가자 목록 조회
+        List<JoinHistory> joinHistories = joinHistoryRepository.findAllByCompetitionId(competitionId);
+        List<CompetitionStartedPayload.Participant> participants = joinHistories.stream()
+                .map(jh -> new CompetitionStartedPayload.Participant(jh.getUserId(), jh.getNickname()))
+                .toList();
+
+        // 3. 이벤트 발행 (계좌 서비스가 컨슘 -> 참가자별 대회 계좌 생성)
+        CompetitionStartedPayload payload = new CompetitionStartedPayload(
+                saved.getCompetitionId(),
+                saved.getName(),
+                saved.getFirstSeed(),
+                participants,
+                LocalDateTime.now()
+        );
+        competitionEventProducer.publishCompetitionStarted(payload);
+
+        return saved;
     }
 
     @Transactional

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/CompetitionServiceImpl.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/CompetitionServiceImpl.java
@@ -123,4 +123,20 @@ public class CompetitionServiceImpl implements CompetitionService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.COMPETITION_NOT_FOUND));
         return competitionChangeNoticeRepository.findAllByCompetitionId(competitionId);
     }
+
+    @Transactional
+    public Competition start(UUID competitionId) {
+        Competition competition = competitionRepository.findById(competitionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
+        competition.startCompetition();
+        return competitionRepository.save(competition);
+    }
+
+    @Transactional
+    public Competition finish(UUID competitionId) {
+        Competition competition = competitionRepository.findById(competitionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
+        competition.finishCompetition();
+        return competitionRepository.save(competition);
+    }
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/CompetitionServiceImpl.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/CompetitionServiceImpl.java
@@ -5,7 +5,7 @@ import common.exception.ErrorCode;
 import io.antcamp.competitionservice.application.dto.CreateCompetitionCommand;
 import io.antcamp.competitionservice.application.dto.UpdateCompetitionCommand;
 import io.antcamp.competitionservice.application.event.CompetitionEventProducer;
-import io.antcamp.competitionservice.domain.event.payload.CompetitionStartedPayload;
+import io.antcamp.competitionservice.domain.event.CompetitionStartedPayload;
 import io.antcamp.competitionservice.domain.model.Competition;
 import io.antcamp.competitionservice.domain.model.CompetitionChangeNotice;
 import io.antcamp.competitionservice.domain.model.CompetitionPeriod;
@@ -162,6 +162,7 @@ public class CompetitionServiceImpl implements CompetitionService {
     }
 
     @Transactional
+    @Override
     public Competition finish(UUID competitionId) {
         Competition competition = competitionRepository.findById(competitionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/JoinHistoryService.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/JoinHistoryService.java
@@ -1,4 +1,9 @@
 package io.antcamp.competitionservice.application;
 
+import io.antcamp.competitionservice.application.dto.JoinCompetitionCommand;
+
 public interface JoinHistoryService {
+    void join(JoinCompetitionCommand command);
+
+    void cancel(JoinCompetitionCommand command);
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/JoinHistoryServiceImpl.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/JoinHistoryServiceImpl.java
@@ -20,19 +20,19 @@ public class JoinHistoryServiceImpl implements JoinHistoryService {
 
     @Transactional
     public void join(JoinCompetitionCommand command) {
-        // 중복 신청 체크 (비관적 락)
+        // 1. 중복 신청 체크 (JoinHistory 비관적 락 - 같은 사용자 동시 신청 방지)
         joinHistoryRepository.findByUserIdAndCompetitionId(command.userId(), command.competitionId())
                 .ifPresent(h -> {
                     throw new BusinessException(ErrorCode.INVALID_INPUT);
                 });
 
-        // 대회 상태 검증 + 참가자 수 증가
-        Competition competition = competitionRepository.findById(command.competitionId())
+        // 2. 대회 조회 (Competition 비관적 락 - 참가자 수 동시성 제어) ← 변경
+        Competition competition = competitionRepository.findByIdForUpdate(command.competitionId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
         competition.register();
         competitionRepository.save(competition);
 
-        // 신청 이력 저장
+        // 3. 신청 이력 저장
         JoinHistory joinHistory = JoinHistory.createJoinHistory(
                 command.userId(),
                 command.nickname(),
@@ -43,18 +43,18 @@ public class JoinHistoryServiceImpl implements JoinHistoryService {
 
     @Transactional
     public void cancel(JoinCompetitionCommand command) {
-        // 신청 이력 조회 (비관적 락)
+        // 1. 신청 이력 조회 (JoinHistory 비관적 락)
         JoinHistory joinHistory = joinHistoryRepository
                 .findByUserIdAndCompetitionId(command.userId(), command.competitionId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
 
-        // 대회 상태 검증 + 참가자 수 감소
-        Competition competition = competitionRepository.findById(command.competitionId())
+        // 2. 대회 조회 (Competition 비관적 락 - 참가자 수 동시성 제어) ← 변경
+        Competition competition = competitionRepository.findByIdForUpdate(command.competitionId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
         competition.cancelRegister();
         competitionRepository.save(competition);
 
-        // 신청 이력 소프트 삭제
+        // 3. 신청 이력 소프트 삭제
         // deletedBy는 임시로 userId 사용 (추후 인증 연동 시 교체)
         joinHistoryRepository.delete(joinHistory, command.userId().toString());
     }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/JoinHistoryServiceImpl.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/JoinHistoryServiceImpl.java
@@ -1,7 +1,61 @@
 package io.antcamp.competitionservice.application;
 
+import common.exception.BusinessException;
+import common.exception.ErrorCode;
+import io.antcamp.competitionservice.application.dto.JoinCompetitionCommand;
+import io.antcamp.competitionservice.domain.model.Competition;
+import io.antcamp.competitionservice.domain.model.JoinHistory;
+import io.antcamp.competitionservice.domain.repository.CompetitionRepository;
+import io.antcamp.competitionservice.domain.repository.JoinHistoryRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class JoinHistoryServiceImpl {
+@RequiredArgsConstructor
+public class JoinHistoryServiceImpl implements JoinHistoryService {
+
+    private final CompetitionRepository competitionRepository;
+    private final JoinHistoryRepository joinHistoryRepository;
+
+    @Transactional
+    public void join(JoinCompetitionCommand command) {
+        // 중복 신청 체크 (비관적 락)
+        joinHistoryRepository.findByUserIdAndCompetitionId(command.userId(), command.competitionId())
+                .ifPresent(h -> {
+                    throw new BusinessException(ErrorCode.INVALID_INPUT);
+                });
+
+        // 대회 상태 검증 + 참가자 수 증가
+        Competition competition = competitionRepository.findById(command.competitionId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
+        competition.register();
+        competitionRepository.save(competition);
+
+        // 신청 이력 저장
+        JoinHistory joinHistory = JoinHistory.createJoinHistory(
+                command.userId(),
+                command.nickname(),
+                command.competitionId()
+        );
+        joinHistoryRepository.save(joinHistory);
+    }
+
+    @Transactional
+    public void cancel(JoinCompetitionCommand command) {
+        // 신청 이력 조회 (비관적 락)
+        JoinHistory joinHistory = joinHistoryRepository
+                .findByUserIdAndCompetitionId(command.userId(), command.competitionId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
+
+        // 대회 상태 검증 + 참가자 수 감소
+        Competition competition = competitionRepository.findById(command.competitionId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
+        competition.cancelRegister();
+        competitionRepository.save(competition);
+
+        // 신청 이력 소프트 삭제
+        // deletedBy는 임시로 userId 사용 (추후 인증 연동 시 교체)
+        joinHistoryRepository.delete(joinHistory, command.userId().toString());
+    }
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/dto/JoinCompetitionCommand.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/dto/JoinCompetitionCommand.java
@@ -1,0 +1,10 @@
+package io.antcamp.competitionservice.application.dto;
+
+import java.util.UUID;
+
+public record JoinCompetitionCommand(
+        UUID competitionId,
+        UUID userId,
+        String nickname
+) {
+}

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/event/CompetitionEventProducer.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/event/CompetitionEventProducer.java
@@ -1,6 +1,6 @@
 package io.antcamp.competitionservice.application.event;
 
-import io.antcamp.competitionservice.domain.event.payload.CompetitionStartedPayload;
+import io.antcamp.competitionservice.domain.event.CompetitionStartedPayload;
 
 /**
  * 대회 도메인 이벤트 발행 인터페이스. 응용 계층은 이 인터페이스에만 의존하고, 실제 발행 메커니즘(Kafka 등)은 인프라 계층에서 구현한다.

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/event/CompetitionEventProducer.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/application/event/CompetitionEventProducer.java
@@ -1,0 +1,11 @@
+package io.antcamp.competitionservice.application.event;
+
+import io.antcamp.competitionservice.domain.event.payload.CompetitionStartedPayload;
+
+/**
+ * 대회 도메인 이벤트 발행 인터페이스. 응용 계층은 이 인터페이스에만 의존하고, 실제 발행 메커니즘(Kafka 등)은 인프라 계층에서 구현한다.
+ */
+public interface CompetitionEventProducer {
+
+    void publishCompetitionStarted(CompetitionStartedPayload payload);
+}

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/event/CompetitionStartedPayload.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/event/CompetitionStartedPayload.java
@@ -1,0 +1,22 @@
+package io.antcamp.competitionservice.domain.event.payload;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 대회 시작 이벤트 페이로드. 계좌 서비스가 컨슘하여 참가자별 대회 전용 계좌를 생성하고 초기 시드머니를 설정한다.
+ */
+public record CompetitionStartedPayload(
+        UUID competitionId,
+        String competitionName,
+        int firstSeed,
+        List<Participant> participants,
+        LocalDateTime startedAt
+) {
+    public record Participant(
+            UUID userId,
+            String nickname
+    ) {
+    }
+}

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/event/CompetitionStartedPayload.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/event/CompetitionStartedPayload.java
@@ -1,4 +1,4 @@
-package io.antcamp.competitionservice.domain.event.payload;
+package io.antcamp.competitionservice.domain.event;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/model/Competition.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/model/Competition.java
@@ -144,13 +144,16 @@ public class Competition {
         this.participantCount = participantCount.decrement();
     }
 
+    // Competition.java 의 startCompetition, finishCompetition 두 메서드만 변경
+
     public void startCompetition() {
         if (status != CompetitionStatus.PREPARING) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
-        if (!competitionPeriod.isOngoing()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
-        }
+        // [변경] 시간 검증 제거 - 운영자 수동 트리거 정책
+        // if (!competitionPeriod.isOngoing()) {
+        //     throw new BusinessException(ErrorCode.INVALID_INPUT);
+        // }
         if (!participantCount.isMetMinimum()) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
@@ -161,9 +164,10 @@ public class Competition {
         if (status != CompetitionStatus.ONGOING) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
-        if (competitionPeriod.isOngoing()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
-        }
+        // [변경] 시간 검증 제거 - 운영자 수동 트리거 정책
+        // if (competitionPeriod.isOngoing()) {
+        //     throw new BusinessException(ErrorCode.INVALID_INPUT);
+        // }
         this.status = CompetitionStatus.FINISHED;
     }
 

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/model/JoinHistory.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/model/JoinHistory.java
@@ -1,52 +1,53 @@
 package io.antcamp.competitionservice.domain.model;
 
+import common.exception.BusinessException;
+import common.exception.ErrorCode;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
-/**
- * 대회 참여자 명부 도메인 클래스 (순수 도메인 모델 - JPA 의존성 없음)
- */
 @Getter
 public class JoinHistory {
 
-    private final UUID joinhistoryId;
+    private final UUID joinHistoryId;
     private final UUID userId;
     private final String nickname;
     private final UUID competitionId;
 
-    @Builder(builderMethodName = "createBuilder", access = AccessLevel.PRIVATE)
-    private JoinHistory(UUID userId, String nickname, UUID competitionId) {
-        this.joinhistoryId = UUID.randomUUID();
+    @Builder(access = AccessLevel.PRIVATE)
+    private JoinHistory(
+            UUID joinHistoryId,
+            UUID userId,
+            String nickname,
+            UUID competitionId
+    ) {
+        this.joinHistoryId = joinHistoryId;
         this.userId = userId;
         this.nickname = nickname;
         this.competitionId = competitionId;
-    }
-
-    @Builder(builderMethodName = "fromBuilder", access = AccessLevel.PRIVATE)
-    private JoinHistory(UUID joinhistoryId, UUID userId, String nickname, UUID competitionId) {
-        this.joinhistoryId = joinhistoryId;
-        this.userId = userId;
-        this.nickname = nickname;
-        this.competitionId = competitionId;
+        validate();
     }
 
     // ─── 정적 팩토리 메서드 ───────────────────────────────────────────────
 
     public static JoinHistory createJoinHistory(UUID userId, String nickname, UUID competitionId) {
-        validate(userId, nickname, competitionId);
-
-        return JoinHistory.createBuilder()
+        return JoinHistory.builder()
+                .joinHistoryId(UUID.randomUUID())
                 .userId(userId)
                 .nickname(nickname)
                 .competitionId(competitionId)
                 .build();
     }
 
-    public static JoinHistory from(UUID participantId, UUID userId, String nickname, UUID competitionId) {
-        return JoinHistory.fromBuilder()
-                .joinhistoryId(participantId)
+    public static JoinHistory from(
+            UUID joinHistoryId,
+            UUID userId,
+            String nickname,
+            UUID competitionId
+    ) {
+        return JoinHistory.builder()
+                .joinHistoryId(joinHistoryId)
                 .userId(userId)
                 .nickname(nickname)
                 .competitionId(competitionId)
@@ -55,20 +56,22 @@ public class JoinHistory {
 
     // ─── 도메인 행위 ─────────────────────────────────────────────────────
 
-    // 같은 대회에 중복 참여하는것을 방지할 떄 사용, 서비스에서 이 값이 true면 예외 반환하도록 작성하자.
     public boolean isSameCompetition(UUID competitionId) {
         return this.competitionId.equals(competitionId);
     }
 
-    private static void validate(UUID userId, String nickname, UUID competitionId) {
+    private void validate() {
+        if (joinHistoryId == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
         if (userId == null) {
-            throw new IllegalArgumentException("유저 ID는 필수입니다.");
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
         if (nickname == null || nickname.isBlank()) {
-            throw new IllegalArgumentException("닉네임은 필수입니다.");
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
         if (competitionId == null) {
-            throw new IllegalArgumentException("대회 ID는 필수입니다.");
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
     }
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/repository/CompetitionRepository.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/repository/CompetitionRepository.java
@@ -13,6 +13,11 @@ public interface CompetitionRepository {
     Optional<Competition> findById(UUID id);
 
     /**
+     * 비관적 락으로 Competition 조회. 참가자 수 변경 시(register/cancelRegister) 동시성 제어를 위해 사용.
+     */
+    Optional<Competition> findByIdForUpdate(UUID id);   // ← 추가
+
+    /**
      * 전체 대회 목록 조회
      */
     Page<Competition> findAll(Pageable pageable);
@@ -23,5 +28,4 @@ public interface CompetitionRepository {
     Page<Competition> findAllByCompetitionStatus(CompetitionStatus status, Pageable pageable);
 
     void delete(Competition competition, String deletedBy);  // 추가
-
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/repository/JoinHistoryRepository.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/repository/JoinHistoryRepository.java
@@ -1,6 +1,7 @@
 package io.antcamp.competitionservice.domain.repository;
 
 import io.antcamp.competitionservice.domain.model.JoinHistory;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,4 +11,6 @@ public interface JoinHistoryRepository {
     Optional<JoinHistory> findByUserIdAndCompetitionId(UUID userId, UUID competitionId);
 
     void delete(JoinHistory joinHistory, String deletedBy);
+
+    List<JoinHistory> findAllByCompetitionId(UUID competitionId);
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/repository/JoinHistoryRepository.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/domain/repository/JoinHistoryRepository.java
@@ -1,4 +1,13 @@
 package io.antcamp.competitionservice.domain.repository;
 
+import io.antcamp.competitionservice.domain.model.JoinHistory;
+import java.util.Optional;
+import java.util.UUID;
+
 public interface JoinHistoryRepository {
+    JoinHistory save(JoinHistory joinHistory);
+
+    Optional<JoinHistory> findByUserIdAndCompetitionId(UUID userId, UUID competitionId);
+
+    void delete(JoinHistory joinHistory, String deletedBy);
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/entity/JoinHistoryEntity.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/entity/JoinHistoryEntity.java
@@ -1,20 +1,24 @@
 package io.antcamp.competitionservice.infrastructure.entity;
 
 import common.entity.BaseEntity;
+import common.exception.BusinessException;
+import common.exception.ErrorCode;
 import io.antcamp.competitionservice.domain.model.JoinHistory;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.persistence.UniqueConstraint;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.domain.Persistable;
 
-/**
- * 대회 참여자 명부 JPA 엔티티 (p_join_historys 테이블 매핑)
- */
 @Entity
 @Table(
         name = "p_join_history",
@@ -27,11 +31,14 @@ import org.hibernate.annotations.SQLRestriction;
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("deleted_at is NULL")
-public class JoinHistoryEntity extends BaseEntity {
+public class JoinHistoryEntity extends BaseEntity implements Persistable<UUID> {
+
+    @Transient
+    private boolean isNew = true;
 
     @Id
-    @Column(name = "participant_id", nullable = false, updatable = false)
-    private UUID joinhistoryId;
+    @Column(name = "join_history_id", nullable = false, updatable = false)
+    private UUID joinHistoryId;
 
     @Column(name = "user_id", nullable = false)
     private UUID userId;
@@ -40,25 +47,68 @@ public class JoinHistoryEntity extends BaseEntity {
     private String nickname;
 
     @Column(name = "competition_id", nullable = false)
-    private UUID competitionId; // 대회 엔티티의 pk ( p_competitions.competition_id 참조 )
+    private UUID competitionId;
 
-    // ─── 정적 팩토리 메서드 ────────────────────────────────────────────────
+    @Builder(access = AccessLevel.PRIVATE)
+    private JoinHistoryEntity(
+            UUID joinHistoryId,
+            UUID userId,
+            String nickname,
+            UUID competitionId
+    ) {
+        this.joinHistoryId = joinHistoryId;
+        this.userId = userId;
+        this.nickname = nickname;
+        this.competitionId = competitionId;
+        validate();
+    }
 
     public static JoinHistoryEntity from(JoinHistory domain) {
-        JoinHistoryEntity entity = new JoinHistoryEntity();
-        entity.joinhistoryId = domain.getJoinhistoryId();
-        entity.userId = domain.getUserId();
-        entity.nickname = domain.getNickname();
-        entity.competitionId = domain.getCompetitionId();
-        return entity;
+        return JoinHistoryEntity.builder()
+                .joinHistoryId(domain.getJoinHistoryId())
+                .userId(domain.getUserId())
+                .nickname(domain.getNickname())
+                .competitionId(domain.getCompetitionId())
+                .build();
     }
 
     public JoinHistory toDomain() {
         return JoinHistory.from(
-                joinhistoryId,
+                joinHistoryId,
                 userId,
                 nickname,
                 competitionId
         );
+    }
+
+    private void validate() {
+        if (joinHistoryId == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (nickname == null || nickname.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (competitionId == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    @Override
+    public UUID getId() {
+        return joinHistoryId;
+    }
+
+    @Override
+    public boolean isNew() {
+        return isNew;
+    }
+
+    @PostLoad
+    @PostPersist
+    void markNotNew() {
+        this.isNew = false;
     }
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/messaging/kafka/CompetitionTopicProperties.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/messaging/kafka/CompetitionTopicProperties.java
@@ -1,0 +1,16 @@
+package io.antcamp.competitionservice.infrastructure.messaging.kafka;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * application.yml의 topics.competition.* 설정을 매핑한다. 토픽명을 코드에 하드코딩하지 않기 위함.
+ */
+@Validated
+@ConfigurationProperties(prefix = "topics.competition")
+public record CompetitionTopicProperties(
+        @NotBlank String started,
+        @NotBlank String finished
+) {
+}

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/messaging/kafka/producer/CompetitionEventProducerImpl.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/messaging/kafka/producer/CompetitionEventProducerImpl.java
@@ -1,0 +1,43 @@
+package io.antcamp.competitionservice.infrastructure.messaging.kafka.producer;
+
+import io.antcamp.competitionservice.application.event.CompetitionEventProducer;
+import io.antcamp.competitionservice.domain.event.payload.CompetitionStartedPayload;
+import io.antcamp.competitionservice.infrastructure.messaging.kafka.CompetitionTopicProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@EnableConfigurationProperties(CompetitionTopicProperties.class)
+public class CompetitionEventProducerImpl implements CompetitionEventProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final CompetitionTopicProperties topicProperties;
+
+
+    // 대회생성이벤트 -> 계좌 서비스
+    @Override
+    public void publishCompetitionStarted(CompetitionStartedPayload payload) {
+        // key를 competitionId로 두면 같은 대회의 이벤트가 같은 파티션으로 라우팅되어 순서 보장됨
+        String key = payload.competitionId().toString();
+        String topic = topicProperties.started();
+
+        kafkaTemplate.send(topic, key, payload)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("[Kafka] CompetitionStartedEvent 발행 실패. competitionId={}, topic={}",
+                                key, topic, ex);
+                    } else {
+                        log.info(
+                                "[Kafka] CompetitionStartedEvent 발행 성공. competitionId={}, topic={}, partition={}, offset={}",
+                                key, topic,
+                                result.getRecordMetadata().partition(),
+                                result.getRecordMetadata().offset());
+                    }
+                });
+    }
+}

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/messaging/kafka/producer/CompetitionEventProducerImpl.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/messaging/kafka/producer/CompetitionEventProducerImpl.java
@@ -1,7 +1,7 @@
 package io.antcamp.competitionservice.infrastructure.messaging.kafka.producer;
 
 import io.antcamp.competitionservice.application.event.CompetitionEventProducer;
-import io.antcamp.competitionservice.domain.event.payload.CompetitionStartedPayload;
+import io.antcamp.competitionservice.domain.event.CompetitionStartedPayload;
 import io.antcamp.competitionservice.infrastructure.messaging.kafka.CompetitionTopicProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +17,6 @@ public class CompetitionEventProducerImpl implements CompetitionEventProducer {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final CompetitionTopicProperties topicProperties;
-
 
     // 대회생성이벤트 -> 계좌 서비스
     @Override

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/persistence/CompetitionJpaRepository.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/persistence/CompetitionJpaRepository.java
@@ -2,11 +2,24 @@ package io.antcamp.competitionservice.infrastructure.persistence;
 
 import io.antcamp.competitionservice.domain.model.CompetitionStatus;
 import io.antcamp.competitionservice.infrastructure.entity.CompetitionEntity;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CompetitionJpaRepository extends JpaRepository<CompetitionEntity, UUID> {
+
     Page<CompetitionEntity> findAllByStatus(CompetitionStatus status, Pageable pageable);
+
+    /**
+     * 비관적 락(SELECT FOR UPDATE)으로 Competition 조회. 참가 신청/취소 시 participantCount의 동시성 제어를 위해 사용.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM CompetitionEntity c WHERE c.competitionId = :id")
+    Optional<CompetitionEntity> findByIdForUpdate(@Param("id") UUID id);
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/persistence/CompetitionRepositoryImpl.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/persistence/CompetitionRepositoryImpl.java
@@ -39,6 +39,12 @@ public class CompetitionRepositoryImpl implements CompetitionRepository {
     }
 
     @Override
+    public Optional<Competition> findByIdForUpdate(UUID id) {
+        return competitionJpaRepository.findByIdForUpdate(id)
+                .map(CompetitionEntity::toDomain);
+    }
+
+    @Override
     public Page<Competition> findAll(Pageable pageable) {
         return competitionJpaRepository.findAll(pageable)
                 .map(CompetitionEntity::toDomain);

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/persistence/JoinHistoryJpaRepository.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/persistence/JoinHistoryJpaRepository.java
@@ -1,8 +1,20 @@
 package io.antcamp.competitionservice.infrastructure.persistence;
 
 import io.antcamp.competitionservice.infrastructure.entity.JoinHistoryEntity;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JoinHistoryJpaRepository extends JpaRepository<JoinHistoryEntity, UUID> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT j FROM JoinHistoryEntity j WHERE j.userId = :userId AND j.competitionId = :competitionId")
+    Optional<JoinHistoryEntity> findByUserIdAndCompetitionIdWithLock(
+            @Param("userId") UUID userId,
+            @Param("competitionId") UUID competitionId
+    );
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/persistence/JoinHistoryJpaRepository.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/persistence/JoinHistoryJpaRepository.java
@@ -2,6 +2,7 @@ package io.antcamp.competitionservice.infrastructure.persistence;
 
 import io.antcamp.competitionservice.infrastructure.entity.JoinHistoryEntity;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,6 @@ public interface JoinHistoryJpaRepository extends JpaRepository<JoinHistoryEntit
             @Param("userId") UUID userId,
             @Param("competitionId") UUID competitionId
     );
+
+    List<JoinHistoryEntity> findAllByCompetitionId(UUID competitionId);
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/persistence/JoinHistoryRepositoryImpl.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/persistence/JoinHistoryRepositoryImpl.java
@@ -5,6 +5,7 @@ import common.exception.ErrorCode;
 import io.antcamp.competitionservice.domain.model.JoinHistory;
 import io.antcamp.competitionservice.domain.repository.JoinHistoryRepository;
 import io.antcamp.competitionservice.infrastructure.entity.JoinHistoryEntity;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -34,5 +35,12 @@ public class JoinHistoryRepositoryImpl implements JoinHistoryRepository {
                 .findByUserIdAndCompetitionIdWithLock(joinHistory.getUserId(), joinHistory.getCompetitionId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
         entity.softDelete(deletedBy);
+    }
+
+    @Override
+    public List<JoinHistory> findAllByCompetitionId(UUID competitionId) {
+        return joinHistoryJpaRepository.findAllByCompetitionId(competitionId).stream()
+                .map(JoinHistoryEntity::toDomain)
+                .toList();
     }
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/persistence/JoinHistoryRepositoryImpl.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/infrastructure/persistence/JoinHistoryRepositoryImpl.java
@@ -1,13 +1,38 @@
 package io.antcamp.competitionservice.infrastructure.persistence;
 
+import common.exception.BusinessException;
+import common.exception.ErrorCode;
+import io.antcamp.competitionservice.domain.model.JoinHistory;
 import io.antcamp.competitionservice.domain.repository.JoinHistoryRepository;
+import io.antcamp.competitionservice.infrastructure.entity.JoinHistoryEntity;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class JoinHistoryRepositoryImpl implements JoinHistoryRepository {
+
     private final JoinHistoryJpaRepository joinHistoryJpaRepository;
 
-    
+    @Override
+    public JoinHistory save(JoinHistory joinHistory) {
+        return joinHistoryJpaRepository.save(JoinHistoryEntity.from(joinHistory)).toDomain();
+    }
+
+    @Override
+    public Optional<JoinHistory> findByUserIdAndCompetitionId(UUID userId, UUID competitionId) {
+        return joinHistoryJpaRepository
+                .findByUserIdAndCompetitionIdWithLock(userId, competitionId)
+                .map(JoinHistoryEntity::toDomain);
+    }
+
+    @Override
+    public void delete(JoinHistory joinHistory, String deletedBy) {
+        JoinHistoryEntity entity = joinHistoryJpaRepository
+                .findByUserIdAndCompetitionIdWithLock(joinHistory.getUserId(), joinHistory.getCompetitionId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
+        entity.softDelete(deletedBy);
+    }
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/presentation/CompetitionController.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/presentation/CompetitionController.java
@@ -148,4 +148,16 @@ public class CompetitionController {
     ) {
         joinHistoryService.cancel(new JoinCompetitionCommand(competitionId, request.userId(), request.nickname()));
     }
+
+    @PatchMapping("/{id}/start")
+    public FindCompetitionResponse start(@PathVariable UUID id) {
+        Competition competition = competitionService.start(id);
+        return FindCompetitionResponse.from(competition);
+    }
+
+    @PatchMapping("/{id}/finish")
+    public FindCompetitionResponse finish(@PathVariable UUID id) {
+        Competition competition = competitionService.finish(id);
+        return FindCompetitionResponse.from(competition);
+    }
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/presentation/CompetitionController.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/presentation/CompetitionController.java
@@ -1,7 +1,9 @@
 package io.antcamp.competitionservice.presentation;
 
 import io.antcamp.competitionservice.application.CompetitionService;
+import io.antcamp.competitionservice.application.JoinHistoryService;
 import io.antcamp.competitionservice.application.dto.CreateCompetitionCommand;
+import io.antcamp.competitionservice.application.dto.JoinCompetitionCommand;
 import io.antcamp.competitionservice.application.dto.UpdateCompetitionCommand;
 import io.antcamp.competitionservice.domain.model.Competition;
 import io.antcamp.competitionservice.domain.model.CompetitionStatus;
@@ -9,6 +11,7 @@ import io.antcamp.competitionservice.presentation.dto.CreateCompetitionRequest;
 import io.antcamp.competitionservice.presentation.dto.CreateCompetitionResponse;
 import io.antcamp.competitionservice.presentation.dto.FindCompetitionChangeNoticeResponse;
 import io.antcamp.competitionservice.presentation.dto.FindCompetitionResponse;
+import io.antcamp.competitionservice.presentation.dto.JoinCompetitionRequest;
 import io.antcamp.competitionservice.presentation.dto.UpdateCompetitionRequest;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -36,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CompetitionController {
 
     private final CompetitionService competitionService;
+    private final JoinHistoryService joinHistoryService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -124,5 +128,24 @@ public class CompetitionController {
                 .stream()
                 .map(FindCompetitionChangeNoticeResponse::from)
                 .toList();
+    }
+
+    // JoinHistory 엔드포인트
+    @PostMapping("/{competitionId}/join")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void join(
+            @PathVariable UUID competitionId,
+            @RequestBody @Valid JoinCompetitionRequest request
+    ) {
+        joinHistoryService.join(new JoinCompetitionCommand(competitionId, request.userId(), request.nickname()));
+    }
+
+    @DeleteMapping("/{competitionId}/join")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void cancel(
+            @PathVariable UUID competitionId,
+            @RequestBody @Valid JoinCompetitionRequest request
+    ) {
+        joinHistoryService.cancel(new JoinCompetitionCommand(competitionId, request.userId(), request.nickname()));
     }
 }

--- a/apps/competition-service/src/main/java/io/antcamp/competitionservice/presentation/dto/JoinCompetitionRequest.java
+++ b/apps/competition-service/src/main/java/io/antcamp/competitionservice/presentation/dto/JoinCompetitionRequest.java
@@ -1,0 +1,11 @@
+package io.antcamp.competitionservice.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record JoinCompetitionRequest(
+        @NotNull UUID userId,       // TODO: 인증 연동 후 헤더/토큰에서 추출로 교체
+        @NotBlank String nickname   // TODO: 인증 연동 후 헤더/토큰에서 추출로 교체
+) {
+}

--- a/apps/competition-service/src/main/resources/application-local.yml
+++ b/apps/competition-service/src/main/resources/application-local.yml
@@ -8,3 +8,13 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
+
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:29092}   # default 살려둠
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      retries: 3
+      properties:
+        spring.json.add.type.headers: false

--- a/apps/competition-service/src/main/resources/application.yaml
+++ b/apps/competition-service/src/main/resources/application.yaml
@@ -10,3 +10,9 @@ spring:
         format_sql: true
 server:
   port: 8092
+
+# [추가] 토픽명 매핑 (CompetitionTopicProperties와 연결)
+topics:
+  competition:
+    started: competition.started
+    finished: competition.finished


### PR DESCRIPTION
## 🌱 설명
> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- 예) 회원가입 API 엔드포인트 추가
- 대회 생성-게시-신청-시작-종료 순서로 api 테스트를 성공
- 대회 신청기간에는 대회를 시작하지 못하던 로직을 날짜 상관없이 관리자가 대회를 시작할 수 있도록 변경
- 대회가 시작하면 대회시작이벤트를 발행

## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- 예) close #12
close #37 

## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat : 새로운 기능 추가
- [ ] fix : 버그 수정
- [ ] !hotfix : 급하게 치명적인 버그 수정
- [ ] refactor : 리팩토링
- [ ] chore : 빌드 설정, 의존성 업데이트 등
- [ ] docs : 문서 수정
- [ ] comment : 필요한 주석 추가 및 변경
- [ ] rename : 파일 또는 폴더 명을 수정하거나 옮기는 작업
- [ ] remove : 파일을 삭제하는 작업
- [ ] test : 테스트 코드, 리팩토링 테스트 코드 추가


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [ ] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)
- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 경쟁 상태 전환: 경쟁을 시작하고 종료하는 PATCH 엔드포인트 추가
  * 참가자 관리: 경쟁 참여(POST) 및 참여 취소(DELETE) 엔드포인트 추가, 입력 유효성 검사 적용
  * 이벤트 통합: 경쟁 시작 시 다운스트림으로 알림을 발행하는 메시지 전송 기능 추가 (토픽 설정 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->