### PR TITLE
fix: docker-compose에 컨피그 설정 적용

### DIFF
--- a/apps/config-server/Dockerfile
+++ b/apps/config-server/Dockerfile
@@ -16,6 +16,8 @@ RUN ./gradlew :apps:config-server:clean :apps:config-server:build -x test --no-d
 
 FROM eclipse-temurin:17-jre
 
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --from=builder /app/apps/config-server/build/libs/*.jar app.jar

--- a/apps/config-server/src/main/resources/application.yaml
+++ b/apps/config-server/src/main/resources/application.yaml
@@ -9,6 +9,7 @@ spring:
           uri: ${CONFIG_GIT_URI:https://github.com/ants-camp/ants-camp-config.git}
           default-label: ${CONFIG_GIT_BRANCH:dev}
           clone-on-start: true
+          search-paths: configs/{application}
 
 management:
   endpoints:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,13 @@ services:
       SERVER_PORT: 8888
       CONFIG_GIT_URI: ${CONFIG_GIT_URI}
       CONFIG_GIT_BRANCH: ${CONFIG_GIT_BRANCH}
+      SPRING_CLOUD_CONFIG_ENABLED: "false"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8888/actuator/health" ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     networks:
       - kafka-network
 
@@ -115,7 +122,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
       JWT_SECRET: ${JWT_SECRET}
       JWT_ACCESS_TOKEN_EXPIRATION: ${JWT_ACCESS_TOKEN_EXPIRATION}
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      CONFIG_SERVER_URL: ${CONFIG_SERVER_URL}
     env_file:
       - .env
     depends_on:
@@ -124,6 +131,8 @@ services:
       postgres:
         condition: service_healthy
       kafka:
+        condition: service_healthy
+      config-server:
         condition: service_healthy
     networks:
       - kafka-network
@@ -151,7 +160,7 @@ services:
       KIS_APP_KEY: ${KIS_APP_KEY}
       KIS_APP_SECRET: ${KIS_APP_SECRET}
       KIS_APP_ACCESS: ${KIS_APP_ACCESS}
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      CONFIG_SERVER_URL: ${CONFIG_SERVER_URL}
     env_file:
       - .env
     volumes:
@@ -162,6 +171,8 @@ services:
       redis:
         condition: service_healthy
       eureka-server:
+        condition: service_healthy
+      config-server:
         condition: service_healthy
     networks:
       - kafka-network
@@ -180,6 +191,8 @@ services:
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka
+      CONFIG_SERVER_URL: ${CONFIG_SERVER_URL}
+
     env_file:
       - .env
     volumes:
@@ -192,6 +205,8 @@ services:
       kafka:
         condition: service_healthy
       eureka-server:
+        condition: service_healthy
+      config-server:
         condition: service_healthy
     networks:
       - kafka-network
@@ -211,6 +226,8 @@ services:
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka
+      CONFIG_SERVER_URL: ${CONFIG_SERVER_URL}
+
     env_file:
       - .env
     volumes:
@@ -223,6 +240,8 @@ services:
       kafka:
         condition: service_healthy
       eureka-server:
+        condition: service_healthy
+      config-server:
         condition: service_healthy
     networks:
       - kafka-network
@@ -242,6 +261,8 @@ services:
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka
+      CONFIG_SERVER_URL: ${CONFIG_SERVER_URL}
+
     env_file:
       - .env
     volumes:
@@ -254,6 +275,8 @@ services:
       kafka:
         condition: service_healthy
       eureka-server:
+        condition: service_healthy
+      config-server:
         condition: service_healthy
     networks:
       - kafka-network
@@ -291,6 +314,7 @@ services:
       GEMINI_API_KEY: ${GEMINI_API_KEY}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka
       ZIPKIN_ENDPOINT: http://zipkin:9411/api/v2/spans
+      CONFIG_SERVER_URL: ${CONFIG_SERVER_URL}
     env_file:
       - .env
     volumes:
@@ -301,6 +325,8 @@ services:
       eureka-server:
         condition: service_healthy
       zipkin:
+        condition: service_healthy
+      config-server:
         condition: service_healthy
     networks:
       - kafka-network
@@ -326,6 +352,7 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: ${SPRING_DATA_REDIS_PORT}
       ZIPKIN_ENDPOINT: http://zipkin:9411/api/v2/spans
+      CONFIG_SERVER_URL: ${CONFIG_SERVER_URL}
     env_file:
       - .env
     volumes:
@@ -339,6 +366,8 @@ services:
       eureka-server:
         condition: service_healthy
       zipkin:
+        condition: service_healthy
+      config-server:
         condition: service_healthy
     networks:
       - kafka-network


### PR DESCRIPTION
## 🌱 설명
> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- `docker-compose.yml`에 `CONFIG_SERVER_URL: ${CONFIG_SERVER_URL}` 추가

```
config-server:
        condition: service_healthy
```

코드를 추가해서, 컨피그가 정상적으로 작동하도록 변경
- `docker-compose.yml`에서 컨피그 서버에 헬스체크 기능 추가

```
healthcheck:
      test: [ "CMD", "curl", "-f", "http://localhost:8888/actuator/health" ]
      interval: 10s
      timeout: 5s
      retries: 10
      start_period: 30s
```

컨피그 서버의 `DockerFile` 에서
`RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*`
부분 추가한 이유는 헬스체크용으로 curl을 이미지 빌드 시 설치하도록 했습니다.

## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- 예) close #12



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 설정 서버의 구성 파일 검색 경로 확장으로 더 유연한 구성 관리 지원
  * 마이크로서비스들이 설정 서버 준비 완료 후 시작되도록 서비스 의존성 개선
  * 컨테이너 이미지 최적화 및 헬스체크 기능 추가로 서비스 안정성 향상

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ants-camp/ants-camp/pull/136)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->