### PR TITLE
fix: 자산-대회종료이벤트 수신 수정

### DIFF
--- a/apps/asset-service/src/main/java/io/antcamp/assetservice/infrastructure/messaging/kafka/consumer/CompetitionEndedEventConsumer.java
+++ b/apps/asset-service/src/main/java/io/antcamp/assetservice/infrastructure/messaging/kafka/consumer/CompetitionEndedEventConsumer.java
@@ -1,26 +1,25 @@
 package io.antcamp.assetservice.infrastructure.messaging.kafka.consumer;
 
 import io.antcamp.assetservice.application.dto.query.ParticipantTotalAssetResult;
+import io.antcamp.assetservice.application.event.TotalAssetEventProducer;
 import io.antcamp.assetservice.application.service.AssetService;
+import io.antcamp.assetservice.domain.event.payload.CompetitionEndedEvent;
 import io.antcamp.assetservice.domain.model.Account;
 import io.antcamp.assetservice.domain.model.Holding;
 import io.antcamp.assetservice.domain.repository.AccountRepository;
 import io.antcamp.assetservice.domain.repository.HoldingRepository;
-import io.antcamp.assetservice.application.event.TotalAssetEventProducer;
 import io.antcamp.assetservice.infrastructure.client.StockPriceClient;
-import io.antcamp.assetservice.domain.event.payload.CompetitionEndedEvent;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
@@ -55,10 +54,11 @@ public class CompetitionEndedEventConsumer {
     @KafkaListener(
             topics = "${topics.competition.finished}",
             groupId = "${spring.kafka.consumer.group-id}",
-            containerFactory = "competitionRegisteredFactory"
+            containerFactory = "competitionEndedFactory"
     )
     public void handleCompetitionEnded(CompetitionEndedEvent payload) {
-        log.info("[Kafka] CompetitionEndedEvent 수신. competitionId={}, 참가자수={}", payload.competitionId(), payload.participantUserIds().size());
+        log.info("[Kafka] CompetitionEndedEvent 수신. competitionId={}, 참가자수={}", payload.competitionId(),
+                payload.participantUserIds().size());
         String lockKey = "lock:competition:ended:" + payload.competitionId();
         String lockToken = UUID.randomUUID().toString();
 
@@ -88,7 +88,8 @@ public class CompetitionEndedEventConsumer {
                     String cacheKey = cachePrefix + holding.getStockCode();
                     Long price = redisTemplate.opsForValue().get(cacheKey);
                     if (price == null) {
-                        price = stockPriceClient.getPriceAt(holding.getStockCode(), payload.endedAt()).getData().longValue();
+                        price = stockPriceClient.getPriceAt(holding.getStockCode(), payload.endedAt()).getData()
+                                .longValue();
                         redisTemplate.opsForValue().set(cacheKey, price, 1, TimeUnit.HOURS);
                     }
                     priceCache.put(holding.getStockCode(), price);

--- a/scenario_all.http
+++ b/scenario_all.http
@@ -181,8 +181,8 @@ Authorization: Bearer {{access_token_0}}
   "description": "유저1 vs 유저2 vs 유저3 수익률 대결",
   "firstSeed": 10000000,
   "registerStartAt": "2026-05-01T00:00:00",
-  "registerEndAt": "2026-05-12T18:56:59",
-  "competitionStartAt": "2026-05-12T19:00:00",
+  "registerEndAt": "2026-05-12T20:55:30",
+  "competitionStartAt": "2026-05-12T20:57:00",
   "competitionEndAt": "2027-12-31T23:59:59",
   "minParticipants": 2,
   "maxParticipants": 100


### PR DESCRIPTION
## 🌱 설명
> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- 예) 회원가입 API 엔드포인트 추가

## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- 예) close #12

자산 서비스에서 대회 종료 이벤트를 정상적으로 수신하여 처리하도록 수정